### PR TITLE
skip_auth flag

### DIFF
--- a/ovos_local_backend/configuration.py
+++ b/ovos_local_backend/configuration.py
@@ -19,6 +19,7 @@ DEFAULT_CONFIG = {
             "ovos-stt-plugin-server": {"url": "https://stt.openvoiceos.com/stt"}},
     "backend_port": 6712,
     "admin_key": "",  # To enable simply set this string to something
+    "skip_auth": False,  # you almost certainly do not want this, only for atypical use cases such as ovos-qubes
     "default_location": {
         "city": {
             "code": "Lawrence",


### PR DESCRIPTION
use cases such as docker or ovos-qubes can not share a identity file between devices, this new flag allows local backend to be used in such cases

this is equivalent to the old behaviour, but previous local backend version did not keep device data so it was safe

be careful! with this option anyone can request device data only with a uuid