### PR TITLE
feat/selene_callout_proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,13 +260,15 @@ wait... what? isn't the point of local backend to disable selene?
 - Privacy, you want to use selene, but you do not want to give away your personal data (email, location, ip address...)
 - Control, you want to use only a subset of selene features
 - Convenience, pair once, manage all your devices
-- Esoteric usage, some setups isolate mycroft services and can not share a identity file, such as [ovos-qubes](https://github.com/OpenVoiceOS/ovos-qubes)
+- Functionality, extra features such as isolated skill settings
+- Esoteric Setups, isolated mycroft services that can not share a identity file, such as [ovos-qubes](https://github.com/OpenVoiceOS/ovos-qubes)
 
 ### Pairing
 
 To pair the local backend with selene you have 2 options
 
 1 - pair a mycroft-core instance, then copy the identity file
+
 2 - enable proxy_pairing, whenever a device pairs with local backend the code it speaks is also valid for selene, use that code to pair local backend with selene
 
 ### Selene Config

--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ wait... what? isn't the point of local backend to disable selene?
 - Privacy, you want to use selene, but you do not want to give away your personal data (email, location, ip address...)
 - Control, you want to use only a subset of selene features
 - Convenience, pair once, manage all your devices
-- Functionality, extra features such as isolated skill settings
+- Functionality, extra features such as isolated skill settings and forced 2 way sync
 - Esoteric Setups, isolated mycroft services that can not share a identity file, such as [ovos-qubes](https://github.com/OpenVoiceOS/ovos-qubes)
 
 ### Pairing
@@ -276,37 +276,45 @@ To pair the local backend with selene you have 2 options
 In your backend config add the following section
 
 ```python
-  "selene": {
-      "enabled": False,  # needs to be explicitly enabled by user
-      "url": "https://api.mycroft.ai",  # change if you are self hosting selene
-      "version": "v1",
-      # pairing settings
-      # NOTE: the file should be used exclusively by backend, do not share with a mycroft-core instance
-      "identity_file": BACKEND_IDENTITY,  # path to identity2.json file
-      # send the pairing from selene to any device that attempts to pair with local backend
-      # this will provide voice/gui prompts to the user and avoid the need to copy a identity file
-      # only happens if backend is not paired with selene (hopefully exactly once)
-      # if False you need to pair an existing mycroft-core as usual and move the file for backend usage
-      "proxy_pairing": False,
-      # micro service settings
-      # NOTE: STT is handled at plugin level, configure ovos-stt-plugin-selene
-      "proxy_weather": True,  # use selene for weather api calls
-      "proxy_wolfram": True,  # use selene for wolfram alpha api calls
-      "proxy_geolocation": True,  # use selene for geolocation api calls
-      "proxy_email": True,  # use selene for sending email (only for email registered in selene)
-      # device settings - if you want to spoof data in selene set these to False
-      "download_location": True,  # set default location from selene
-      "download_prefs": True,  # set default device preferences from selene
-      "download_settings": True,  # download shared skill settings from selene
-      "upload_settings": True,  # upload shared skill settings to selene
-      # opt-in settings - what data to share with selene
-      # NOTE: these also depend on opt_in being set in selene
-      "opt_in": False,  # share data from all devices with selene (as if from a single device)
-      "opt_in_blacklist": [],  # list of uuids that should ignore opt_in flag (never share data)
-      "upload_metrics": True,  # upload device metrics to selene
-      "upload_wakewords": True,  # upload wake word samples to selene
-      "upload_utterances": True  # upload utterance samples to selene
-  }
+    "selene": {
+        "enabled": False,  # needs to be explicitly enabled by user
+        "url": "https://api.mycroft.ai",  # change if you are self hosting selene
+        "version": "v1",
+        # pairing settings
+        # NOTE: the file should be used exclusively by backend, do not share with a mycroft-core instance
+        "identity_file": BACKEND_IDENTITY,  # path to identity2.json file
+        # send the pairing from selene to any device that attempts to pair with local backend
+        # this will provide voice/gui prompts to the user and avoid the need to copy a identity file
+        # only happens if backend is not paired with selene (hopefully exactly once)
+        # if False you need to pair an existing mycroft-core as usual and move the file for backend usage
+        "proxy_pairing": False,
+        
+        # micro service settings
+        # NOTE: STT is handled at plugin level, configure ovos-stt-plugin-selene
+        "proxy_weather": True,  # use selene for weather api calls
+        "proxy_wolfram": True,  # use selene for wolfram alpha api calls
+        "proxy_geolocation": True,  # use selene for geolocation api calls
+        "proxy_email": True,  # use selene for sending email (only for email registered in selene)
+        
+        # device settings - if you want to spoof data in selene set these to False
+        "download_location": True,  # set default location from selene
+        "download_prefs": True,  # set default device preferences from selene
+        "download_settings": True,  # download shared skill settings from selene
+        "upload_settings": True,  # upload shared skill settings to selene
+        "force2way": False,  # this forcefully re-enables 2way settings sync with selene
+        # this functionality was removed from core, we hijack the settingsmeta endpoint to upload settings
+        # upload will happen when mycroft-core boots and overwrite any values in selene (no checks for settings changed)
+        # the assumption is that selene changes are downloaded instantaneously
+        # if a device is offline when selene changes those changes will be discarded on next device boot
+        
+        # opt-in settings - what data to share with selene
+        # NOTE: these also depend on opt_in being set in selene
+        "opt_in": False,  # share data from all devices with selene (as if from a single device)
+        "opt_in_blacklist": [],  # list of uuids that should ignore opt_in flag (never share data)
+        "upload_metrics": True,  # upload device metrics to selene
+        "upload_wakewords": True,  # upload wake word samples to selene
+        "upload_utterances": True  # upload utterance samples to selene
+    }
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -271,6 +271,7 @@ To pair the local backend with selene you have 2 options
 
 2 - enable proxy_pairing, whenever a device pairs with local backend the code it speaks is also valid for selene, use that code to pair local backend with selene
 
+If a device tries to use a selene enabled endpoint without the backend being paired a 401 authentication error will be returned, if the endpoint does not use selene (eg. disabled in config) this check is skipped
 ### Selene Config
 
 In your backend config add the following section

--- a/README.md
+++ b/README.md
@@ -294,7 +294,7 @@ In your backend config add the following section
         "proxy_weather": True,  # use selene for weather api calls
         "proxy_wolfram": True,  # use selene for wolfram alpha api calls
         "proxy_geolocation": True,  # use selene for geolocation api calls
-        "proxy_email": True,  # use selene for sending email (only for email registered in selene)
+        "proxy_email": False,  # use selene for sending email (only for email registered in selene)
         
         # device settings - if you want to spoof data in selene set these to False
         "download_location": True,  # set default location from selene

--- a/README.md
+++ b/README.md
@@ -99,7 +99,60 @@ By default admin api is disabled, to enable it add `"admin_key": "unique_super_s
 
 you need to provide that key in the request headers for [admin endpoints](./ovos_local_backend/backend/admin.py)
 
-TODO - [selene_api](https://github.com/OpenVoiceOS/selene_api) support
+```python
+from selene_api.api import AdminApi
+
+admin = AdminApi("secret_admin_key")
+
+uuid = "..."  # check identity2.json in the device you want to manage
+
+# manually pair a device
+identity_json = admin.pair(uuid)
+
+# set device info
+info = {"opt_in": True,
+        "name": "my_device",
+        "device_location": "kitchen",
+        "email": "notifications@me.com",
+        "isolated_skills": False,
+        "lang": "en-us"}
+admin.set_device_info(uuid, info)
+
+# set device preferences
+prefs = {"time_format": "full",
+        "date_format": "DMY",
+        "system_unit": "metric",
+        "lang": "en-us"}
+admin.set_device_prefs(uuid, prefs)
+
+# set location data
+loc = {
+    "city": {
+        "code": "Lawrence",
+        "name": "Lawrence",
+        "state": {
+            "code": "KS",
+            "name": "Kansas",
+            "country": {
+                "code": "US",
+                "name": "United States"
+            }
+        }
+    },
+    "coordinate": {
+        "latitude": 38.971669,
+        "longitude": -95.23525
+    },
+    "timezone": {
+        "code": "America/Chicago",
+        "name": "Central Standard Time",
+        "dstOffset": 3600000,
+        "offset": -21600000
+    }
+}
+admin.set_device_location(uuid, loc)
+```
+
 
 ## Device Settings
 
@@ -195,6 +248,65 @@ with the local backend you need to configure your own SMTP server and recipient 
 ```
 
 If using gmail you will need to [enable less secure apps](https://hotter.io/docs/email-accounts/secure-app-gmail/)
+
+
+## Selene Proxy
+
+You can integrate local backend with selene, the backend will show up as a device you can manage in mycroft.home
+
+wait... what? isn't the point of local backend to disable selene?
+
+- Open Dataset, You do not want to use selene, but you want to opt_in to the open dataset (share recordings with mycroft)
+- Privacy, you want to use selene, but you do not want to give away your personal data (email, location, ip address...)
+- Control, you want to use only a subset of selene features
+- Convenience, pair once, manage all your devices
+- Esoteric usage, some setups isolate mycroft services and can not share a identity file, such as [ovos-qubes](https://github.com/OpenVoiceOS/ovos-qubes)
+
+### Pairing
+
+To pair the local backend with selene you have 2 options
+
+1 - pair a mycroft-core instance, then copy the identity file
+2 - enable proxy_pairing, whenever a device pairs with local backend the code it speaks is also valid for selene, use that code to pair local backend with selene
+
+### Selene Config
+
+In your backend config add the following section
+
+```python
+  "selene": {
+      "enabled": False,  # needs to be explicitly enabled by user
+      "url": "https://api.mycroft.ai",  # change if you are self hosting selene
+      "version": "v1",
+      # pairing settings
+      # NOTE: the file should be used exclusively by backend, do not share with a mycroft-core instance
+      "identity_file": BACKEND_IDENTITY,  # path to identity2.json file
+      # send the pairing from selene to any device that attempts to pair with local backend
+      # this will provide voice/gui prompts to the user and avoid the need to copy a identity file
+      # only happens if backend is not paired with selene (hopefully exactly once)
+      # if False you need to pair an existing mycroft-core as usual and move the file for backend usage
+      "proxy_pairing": False,
+      # micro service settings
+      # NOTE: STT is handled at plugin level, configure ovos-stt-plugin-selene
+      "proxy_weather": True,  # use selene for weather api calls
+      "proxy_wolfram": True,  # use selene for wolfram alpha api calls
+      "proxy_geolocation": True,  # use selene for geolocation api calls
+      "proxy_email": True,  # use selene for sending email (only for email registered in selene)
+      # device settings - if you want to spoof data in selene set these to False
+      "download_location": True,  # set default location from selene
+      "download_prefs": True,  # set default device preferences from selene
+      "download_settings": True,  # download shared skill settings from selene
+      "upload_settings": True,  # upload shared skill settings to selene
+      # opt-in settings - what data to share with selene
+      # NOTE: these also depend on opt_in being set in selene
+      "opt_in": False,  # share data from all devices with selene (as if from a single device)
+      "opt_in_blacklist": [],  # list of uuids that should ignore opt_in flag (never share data)
+      "upload_metrics": True,  # upload device metrics to selene
+      "upload_wakewords": True,  # upload wake word samples to selene
+      "upload_utterances": True  # upload utterance samples to selene
+  }
+```
+
 
 ## Mycroft Setup
 

--- a/ovos_local_backend/backend/decorators.py
+++ b/ovos_local_backend/backend/decorators.py
@@ -41,7 +41,8 @@ def requires_opt_in(f):
 def check_selene_pairing(f):
     @wraps(f)
     def decorated(*args, **kwargs):
-        attempt_selene_pairing()
+        if CONFIGURATION.get("selene", {}).get("proxy_pairing"):
+            attempt_selene_pairing()
         requires_selene = requires_selene_pairing(f.__name__)
         # check pairing with selene
         if requires_selene and not is_paired():

--- a/ovos_local_backend/backend/device.py
+++ b/ovos_local_backend/backend/device.py
@@ -10,25 +10,37 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-import json
 import time
 from flask import request
 
+from ovos_local_backend.configuration import CONFIGURATION
 from ovos_local_backend.backend import API_VERSION
-from ovos_local_backend.backend.decorators import noindex, requires_auth
+from ovos_local_backend.backend.decorators import noindex, requires_auth, check_selene_pairing
 from ovos_local_backend.database.metrics import save_metric
 from ovos_local_backend.database.settings import DeviceDatabase, SkillSettings, SettingsDatabase
 from ovos_local_backend.utils import generate_code, nice_json
 from ovos_local_backend.utils.geolocate import get_request_location
 from ovos_local_backend.utils.mail import send_email
-
+from ovos_local_backend.utils.selene import get_selene_code
+from selene_api.api import DeviceApi
+from selene_api.pairing import is_paired
 
 
 def get_device_routes(app):
     @app.route("/v1/device/<uuid>/settingsMeta", methods=['PUT'])
+    @check_selene_pairing
     @requires_auth
     def settingsmeta(uuid):
         """ new style skill settings meta (upload only) """
+        selene_cfg = CONFIGURATION.get("selene") or {}
+        if selene_cfg.get("enabled") and selene_cfg.get("upload_settings"):
+            url = selene_cfg.get("url")
+            version = selene_cfg.get("version") or "v1"
+            identity_file = selene_cfg.get("identity_file")
+            # TODO - upload settings meta to selene if enabled
+            # TODO - force 2-way-sync flag
+
+        # save new settings meta to db
         with SettingsDatabase() as db:
             s = SkillSettings.deserialize(request.json)
             # keep old settings, update meta only
@@ -40,25 +52,47 @@ def get_device_routes(app):
         return nice_json({"success": True, "uuid": uuid})
 
     @app.route("/v1/device/<uuid>/skill/settings", methods=['GET'])
+    @check_selene_pairing
     @requires_auth
     def skill_settings_v2(uuid):
         """ new style skill settings (download only)"""
+        selene_cfg = CONFIGURATION.get("selene") or {}
+        if selene_cfg.get("enabled") and selene_cfg.get("download_settings"):
+            url = selene_cfg.get("url")
+            version = selene_cfg.get("version") or "v1"
+            identity_file = selene_cfg.get("identity_file")
+            # TODO - get settings from selene if enabled
+
         db = SettingsDatabase()
         return {s.skill_id: s.settings for s in db.get_device_settings(uuid)}
 
     @app.route("/v1/device/<uuid>/skill", methods=['GET', 'PUT'])
+    @check_selene_pairing
     @requires_auth
     def skill_settings(uuid):
         """ old style skill settings/settingsmeta - supports 2 way sync
          PUT - json for 1 skill
          GET - list of all skills """
+        selene_cfg = CONFIGURATION.get("selene") or {}
+        url = selene_cfg.get("url")
+        version = selene_cfg.get("version") or "v1"
+        identity_file = selene_cfg.get("identity_file")
+
         if request.method == 'PUT':
+            if selene_cfg.get("enabled") and selene_cfg.get("upload_settings"):
+                # TODO - upload settings to selene if enabled
+                pass
+
             with SettingsDatabase() as db:
                 s = SkillSettings.deserialize(request.json)
                 db.add_setting(uuid, s.skill_id, s.settings, s.meta,
                                s.display_name, s.remote_id)
             return nice_json({"success": True, "uuid": uuid})
         else:
+            if selene_cfg.get("enabled") and selene_cfg.get("upload_settings"):
+                # TODO - get settings from selene if enabled
+                pass
+
             return nice_json([s.serialize() for s in SettingsDatabase().get_device_settings(uuid)])
 
     @app.route("/v1/device/<uuid>/skillJson", methods=['PUT'])
@@ -66,6 +100,8 @@ def get_device_routes(app):
     def skill_json(uuid):
         """ device is communicating to the backend what skills are installed
         drop the info and don't track it! maybe if we add a UI and it becomes useful..."""
+        # TODO - do we care about sending this to selene? seems optional....
+        # everything works in skill settings without using this
         data = request.json
         # {'blacklist': [],
         # 'skills': [{'name': 'fallback-unknown',
@@ -80,23 +116,57 @@ def get_device_routes(app):
 
     @app.route("/" + API_VERSION + "/device/<uuid>/location", methods=['GET'])
     @requires_auth
+    @check_selene_pairing
     @noindex
     def location(uuid):
+        # get location from selene if enabled
+        selene_cfg = CONFIGURATION.get("selene") or {}
+        if selene_cfg.get("enabled") and selene_cfg.get("download_location"):
+            url = selene_cfg.get("url")
+            version = selene_cfg.get("version") or "v1"
+            identity_file = selene_cfg.get("identity_file")
+            api = DeviceApi(url, version, identity_file)
+            # update in local db
+            loc = api.get_location()
+            with DeviceDatabase() as db:
+                device = db.get_device(uuid)
+                device.location = loc
+                db.update_device(device)
+            return loc
+
         device = DeviceDatabase().get_device(uuid)
         if device:
             return device.location
         return get_request_location()
 
     @app.route("/" + API_VERSION + "/device/<uuid>/setting", methods=['GET'])
+    @check_selene_pairing
     @requires_auth
     @noindex
     def setting(uuid=""):
+        # get/update device preferences from selene if enabled
+        selene_cfg = CONFIGURATION.get("selene") or {}
+        if selene_cfg.get("enabled") and selene_cfg.get("download_prefs"):
+            url = selene_cfg.get("url")
+            version = selene_cfg.get("version") or "v1"
+            identity_file = selene_cfg.get("identity_file")
+            api = DeviceApi(url, version, identity_file)
+            data = api.get_settings()
+            # update in local db
+            with DeviceDatabase() as db:
+                device = db.get_device(uuid)
+                device.system_unit = data["systemUnit"]
+                device.time_format = data["timeFormat"]
+                device.date_format = data["dateFormat"]
+                db.update_device(device)
+
         device = DeviceDatabase().get_device(uuid)
         if device:
             return device.selene_settings
         return {}
 
     @app.route("/" + API_VERSION + "/device/<uuid>", methods=['PATCH', 'GET'])
+    @check_selene_pairing
     @requires_auth
     @noindex
     def get_uuid(uuid):
@@ -108,16 +178,38 @@ def get_device_routes(app):
             # 'platform_build': None,
             # 'enclosureVersion': None}
             return {}
-        with DeviceDatabase() as db:
-            device = db.get_device(uuid)
-            if device:
-                return device.selene_device
+
+        # get/update device_name and device_location from selene if enabled
+        selene_cfg = CONFIGURATION.get("selene") or {}
+        if selene_cfg.get("enabled") and selene_cfg.get("download_prefs"):
+            url = selene_cfg.get("url")
+            version = selene_cfg.get("version") or "v1"
+            identity_file = selene_cfg.get("identity_file")
+            api = DeviceApi(url, version, identity_file)
+            data = api.get()
+            device_location = data.get("description") or "unknown"
+            device_name = data.get("name") or "unknown"
+            # update local db with remote info
+            with DeviceDatabase() as db:
+                device = db.get_device(uuid)
+                device.name = device_name
+                device.device_location = device_location
+                db.update_device(device)
+        else:
+            device_location = device_name = "unknown"
+
+        # get from local db
+        device = DeviceDatabase().get_device(uuid)
+        if device:
+            return device.selene_device
+
+        # dummy valid data
         token = request.headers.get('Authorization', '').replace("Bearer ", "")
         uuid = token.split(":")[-1]
         return {
-            "description": "unknown",
+            "description": device_location,
             "uuid": uuid,
-            "name": "unknown",
+            "name": device_name,
             # not tracked / meaningless
             # just for api compliance with selene
             'coreVersion': "unknown",
@@ -134,6 +226,19 @@ def get_device_routes(app):
         """
         uuid = request.args["state"]
         code = generate_code()
+
+        # if selene enabled and not paired
+        #  return selene pairing code
+        #  only ask it from selene once, return same code to all devices
+        #  devices are only being used to prompt the user for action in backend
+        selene_cfg = CONFIGURATION.get("selene") or {}
+        if selene_cfg.get("enabled") and not is_paired():
+            # pairing device with backend + backend with selene
+            # share spoken code for simplicity
+            # hijacking devices to speak prompts for selene pairing
+            code = get_selene_code() or code
+
+        # pairing device with backend
         token = f"{code}:{uuid}"
         result = {"code": code, "uuid": uuid, "token": token,
                   # selene api compat
@@ -165,48 +270,83 @@ def get_device_routes(app):
 
     @app.route("/" + API_VERSION + "/device/<uuid>/message", methods=['PUT'])
     @noindex
+    @check_selene_pairing
     @requires_auth
     def send_mail(uuid=""):
+
+        data = request.json
+        skill_id = data["sender"]  # TODO - auto append to body ?
+
+        selene_cfg = CONFIGURATION.get("selene") or {}
+        if selene_cfg.get("enabled") and selene_cfg.get("proxy_email"):
+            url = selene_cfg.get("url")
+            version = selene_cfg.get("version") or "v1"
+            identity_file = selene_cfg.get("identity_file")
+            api = DeviceApi(url, version, identity_file)
+            return api.send_email(data["title"], data["body"], skill_id)
+
         target_email = None
         device = DeviceDatabase().get_device(uuid)
         if device:
             target_email = device.email
-        data = request.json
-        skill_id = data["sender"]  # TODO - auto append to body ?
         send_email(data["title"], data["body"], target_email)
 
     @app.route("/" + API_VERSION + "/device/<uuid>/metric/<name>", methods=['POST'])
     @noindex
+    @check_selene_pairing
     @requires_auth
     def metric(uuid="", name=""):
         data = request.json
 
         save_metric(uuid, name, data)
 
-        # TODO - share with upstream setting
         # contribute to mycroft metrics dataset
         # may require https://github.com/OpenVoiceOS/OVOS-local-backend/issues/20
-        uploaded = False
-        upload_data = {"uploaded": uploaded}
+        selene_cfg = CONFIGURATION.get("selene") or {}
+        if selene_cfg.get("enabled") and \
+                selene_cfg.get("upload_metrics") and \
+                selene_cfg.get("opt_in"):
+            url = selene_cfg.get("url")
+            version = selene_cfg.get("version") or "v1"
+            identity_file = selene_cfg.get("identity_file")
+            api = DeviceApi(url, version, identity_file)
+            return api.report_metric(name, data)
 
         return nice_json({"success": True,
                           "uuid": uuid,
                           "metric": data,
-                          "upload_data": upload_data})
+                          "upload_data": {"uploaded": False}})
 
     @app.route("/" + API_VERSION + "/device/<uuid>/subscription", methods=['GET'])
     @noindex
     @requires_auth
     def subscription_type(uuid=""):
-        sub_type = "free"
-        subscription = {"@type": sub_type}
+        # if selene enabled and paired check type in selene
+        selene_cfg = CONFIGURATION.get("selene") or {}
+        if selene_cfg.get("enabled") and is_paired():
+            url = selene_cfg.get("url")
+            version = selene_cfg.get("version") or "v1"
+            identity_file = selene_cfg.get("identity_file")
+            api = DeviceApi(url, version, identity_file)
+            return api.get_subscription()
+
+        subscription = {"@type": "free"}
         return nice_json(subscription)
 
     @app.route("/" + API_VERSION + "/device/<uuid>/voice", methods=['GET'])
     @noindex
+    @check_selene_pairing
     @requires_auth
     def get_subscriber_voice_url(uuid=""):
         arch = request.args["arch"]
+        # if selene enabled and paired return premium voice data
+        selene_cfg = CONFIGURATION.get("selene") or {}
+        if selene_cfg.get("enabled") and is_paired():
+            url = selene_cfg.get("url")
+            version = selene_cfg.get("version") or "v1"
+            identity_file = selene_cfg.get("identity_file")
+            api = DeviceApi(url, version, identity_file)
+            return api.get_subscriber_voice_url(arch=arch)
         return nice_json({"link": "", "arch": arch})
 
     return app

--- a/ovos_local_backend/backend/device.py
+++ b/ovos_local_backend/backend/device.py
@@ -21,7 +21,8 @@ from ovos_local_backend.database.settings import DeviceDatabase, SkillSettings, 
 from ovos_local_backend.utils import generate_code, nice_json
 from ovos_local_backend.utils.geolocate import get_request_location
 from ovos_local_backend.utils.mail import send_email
-from ovos_local_backend.utils.selene import get_selene_code, selene_opted_in
+from ovos_local_backend.utils.selene import get_selene_code, selene_opted_in, \
+    download_selene_skill_settings, upload_selene_skill_settings, upload_selene_skill_settingsmeta
 from selene_api.api import DeviceApi
 from selene_api.pairing import is_paired
 
@@ -32,13 +33,10 @@ def get_device_routes(app):
     @requires_auth
     def settingsmeta(uuid):
         """ new style skill settings meta (upload only) """
+        # upload settings meta to selene if enabled
         selene_cfg = CONFIGURATION.get("selene") or {}
-        if selene_cfg.get("enabled") and selene_cfg.get("upload_settings"):
-            url = selene_cfg.get("url")
-            version = selene_cfg.get("version") or "v1"
-            identity_file = selene_cfg.get("identity_file")
-            # TODO - upload settings meta to selene if enabled
-            # TODO - force 2-way-sync flag
+        if selene_cfg.get("upload_settings"):
+            upload_selene_skill_settingsmeta(request.json)
 
         # save new settings meta to db
         with SettingsDatabase() as db:
@@ -56,12 +54,10 @@ def get_device_routes(app):
     @requires_auth
     def skill_settings_v2(uuid):
         """ new style skill settings (download only)"""
+        # get settings from selene if enabled
         selene_cfg = CONFIGURATION.get("selene") or {}
-        if selene_cfg.get("enabled") and selene_cfg.get("download_settings"):
-            url = selene_cfg.get("url")
-            version = selene_cfg.get("version") or "v1"
-            identity_file = selene_cfg.get("identity_file")
-            # TODO - get settings from selene if enabled
+        if selene_cfg.get("download_settings"):
+            download_selene_skill_settings()
 
         db = SettingsDatabase()
         return {s.skill_id: s.settings for s in db.get_device_settings(uuid)}
@@ -74,24 +70,21 @@ def get_device_routes(app):
          PUT - json for 1 skill
          GET - list of all skills """
         selene_cfg = CONFIGURATION.get("selene") or {}
-        url = selene_cfg.get("url")
-        version = selene_cfg.get("version") or "v1"
-        identity_file = selene_cfg.get("identity_file")
-
         if request.method == 'PUT':
-            if selene_cfg.get("enabled") and selene_cfg.get("upload_settings"):
-                # TODO - upload settings to selene if enabled
-                pass
+            if selene_cfg.get("upload_settings"):
+                # upload settings to selene if enabled
+                upload_selene_skill_settings(request.json)
 
+            # update local db
             with SettingsDatabase() as db:
                 s = SkillSettings.deserialize(request.json)
                 db.add_setting(uuid, s.skill_id, s.settings, s.meta,
                                s.display_name, s.remote_id)
             return nice_json({"success": True, "uuid": uuid})
         else:
-            if selene_cfg.get("enabled") and selene_cfg.get("upload_settings"):
-                # TODO - get settings from selene if enabled
-                pass
+            if selene_cfg.get("download_settings"):
+                # get settings from selene if enabled
+                download_selene_skill_settings()
 
             return nice_json([s.serialize() for s in SettingsDatabase().get_device_settings(uuid)])
 
@@ -207,15 +200,13 @@ def get_device_routes(app):
         uuid = request.args["state"]
         code = generate_code()
 
-        # if selene enabled and not paired
-        #  return selene pairing code
+        # if selene enabled and not paired return selene pairing code
         #  only ask it from selene once, return same code to all devices
         #  devices are only being used to prompt the user for action in backend
         selene_cfg = CONFIGURATION.get("selene") or {}
-        if selene_cfg.get("enabled") and not is_paired():
+        if selene_cfg.get("enabled") and selene_cfg.get("proxy_pairing") and not is_paired():
             # pairing device with backend + backend with selene
             # share spoken code for simplicity
-            # hijacking devices to speak prompts for selene pairing
             code = get_selene_code() or code
 
         # pairing device with backend

--- a/ovos_local_backend/backend/device.py
+++ b/ovos_local_backend/backend/device.py
@@ -49,12 +49,11 @@ def get_device_routes(app):
         # upload settings meta to selene if enabled
         selene_cfg = CONFIGURATION.get("selene") or {}
         if selene_cfg.get("upload_settings"):
-            s = s.serialize()
             if selene_cfg.get("force2way"):
                 # forced 2 way sync
-                upload_selene_skill_settings(s)
+                upload_selene_skill_settings(s.serialize())
             else:
-                upload_selene_skill_settingsmeta(s)
+                upload_selene_skill_settingsmeta(s.meta)
 
         return nice_json({"success": True, "uuid": uuid})
 

--- a/ovos_local_backend/backend/external_apis.py
+++ b/ovos_local_backend/backend/external_apis.py
@@ -17,6 +17,14 @@ if not CONFIGURATION.get("wolfram_key"):
 if not CONFIGURATION.get("owm_key"):
     _owm = OvosWeather()
 
+_selene_cfg = CONFIGURATION.get("selene") or {}
+_url = _selene_cfg.get("url")
+_version = _selene_cfg.get("version") or "v1"
+_identity_file = _selene_cfg.get("identity_file")
+_selene_owm = OpenWeatherMapApi(_url, _version, _identity_file)
+_selene_wolf = WolframAlphaApi(_url, _version, _identity_file)
+_selene_geo = GeolocationApi(_url, _version, _identity_file)
+
 
 def _get_lang():
     auth = request.headers.get('Authorization', '').replace("Bearer ", "")
@@ -57,13 +65,8 @@ def get_services_routes(app):
     def geolocation():
         address = request.args["location"]
 
-        selene_cfg = CONFIGURATION.get("selene") or {}
-        if selene_cfg.get("enabled") and selene_cfg.get("proxy_geolocation"):
-            url = selene_cfg.get("url")
-            version = selene_cfg.get("version") or "v1"
-            identity_file = selene_cfg.get("identity_file")
-            api = GeolocationApi(url, version, identity_file)
-            data = api.get_geolocation(address)
+        if _selene_cfg.get("enabled") and _selene_cfg.get("proxy_geolocation"):
+            data = _selene_geo.get_geolocation(address)
         else:
             data = geolocate(address)
         return {"data": {
@@ -89,15 +92,9 @@ def get_services_routes(app):
         # not used?
         # https://products.wolframalpha.com/spoken-results-api/documentation/
         lat, lon = _get_latlon()
-        # geolocation = request.args.get("geolocation") or lat + " " + lon
 
-        selene_cfg = CONFIGURATION.get("selene") or {}
-        if selene_cfg.get("enabled") and selene_cfg.get("proxy_wolfram"):
-            url = selene_cfg.get("url")
-            version = selene_cfg.get("version") or "v1"
-            identity_file = selene_cfg.get("identity_file")
-            api = WolframAlphaApi(url, version, identity_file)
-            answer = api.spoken(query, units, (lat, lon))
+        if _selene_cfg.get("enabled") and _selene_cfg.get("proxy_wolfram"):
+            answer = _selene_wolf.spoken(query, units, (lat, lon))
         elif _wolfie:
             q = {"input": query, "units": units}
             answer = _wolfie.get_wolfram_spoken(q)
@@ -122,9 +119,11 @@ def get_services_routes(app):
 
         # not used?
         # https://products.wolframalpha.com/spoken-results-api/documentation/
-        # lat, lon = _get_latlon()
-        # geolocation = request.args.get("geolocation") or lat + " " + lon
-        if _wolfie:
+        lat, lon = _get_latlon()
+
+        if _selene_cfg.get("enabled") and _selene_cfg.get("proxy_wolfram"):
+            answer = _selene_wolf.simple(query, units, (lat, lon))
+        elif _wolfie:
             q = {"input": query, "units": units}
             answer = _wolfie.get_wolfram_simple(q)
         else:
@@ -149,15 +148,9 @@ def get_services_routes(app):
         # not used?
         # https://products.wolframalpha.com/spoken-results-api/documentation/
         lat, lon = _get_latlon()
-        # geolocation = request.args.get("geolocation") or lat + " " + lon
 
-        selene_cfg = CONFIGURATION.get("selene") or {}
-        if selene_cfg.get("enabled") and selene_cfg.get("proxy_wolfram"):
-            url = selene_cfg.get("url")
-            version = selene_cfg.get("version") or "v1"
-            identity_file = selene_cfg.get("identity_file")
-            api = WolframAlphaApi(url, version, identity_file)
-            answer = api.full_results(query, units, (lat, lon))
+        if _selene_cfg.get("enabled") and _selene_cfg.get("proxy_wolfram"):
+            answer = _selene_wolf.full_results(query, units, (lat, lon))
         elif _wolfie:
             q = {"input": query, "units": units}
             answer = _wolfie.get_wolfram_full(q)
@@ -185,15 +178,9 @@ def get_services_routes(app):
         # not used?
         # https://products.wolframalpha.com/spoken-results-api/documentation/
         lat, lon = _get_latlon()
-        # geolocation = request.args.get("geolocation") or lat + " " + lon
 
-        selene_cfg = CONFIGURATION.get("selene") or {}
-        if selene_cfg.get("enabled") and selene_cfg.get("proxy_wolfram"):
-            url = selene_cfg.get("url")
-            version = selene_cfg.get("version") or "v1"
-            identity_file = selene_cfg.get("identity_file")
-            api = WolframAlphaApi(url, version, identity_file)
-            answer = api.full_results(query, units, (lat, lon), {"output": "xml"})
+        if _selene_cfg.get("enabled") and _selene_cfg.get("proxy_wolfram"):
+            answer = _selene_wolf.full_results(query, units, (lat, lon), {"output": "xml"})
         elif _wolfie:
             q = {"input": query, "units": units, "output": "xml"}
             answer = _wolfie.get_wolfram_full(q)
@@ -211,20 +198,26 @@ def get_services_routes(app):
     @check_selene_pairing
     @requires_auth
     def owm_daily_forecast():
-        params = dict(request.args)
-        params["lang"] = request.args.get("lang") or _get_lang()
-        params["units"] = request.args.get("units") or _get_units()
+        lang = request.args.get("lang") or _get_lang()
+        units = request.args.get("units") or _get_units()
         lat, lon = request.args.get("lat"), request.args.get("lon")
         if not lat or not lon:
             lat, lon = _get_latlon()
 
+        if _selene_cfg.get("enabled") and _selene_cfg.get("proxy_weather"):
+            return _selene_owm.get_daily((lat, lon), lang, units)
+
+        params = dict(request.args)
+        params["lang"] = lang
+        params["units"] = units
         if _owm:
             params["lat"], params["lon"] = lat, lon
             return _owm.get_forecast(params).json()
 
+        params = dict(request.args)
+        params["appid"] = CONFIGURATION["owm_key"]
         if not request.args.get("q"):
             params["lat"], params["lon"] = lat, lon
-        params["appid"] = CONFIGURATION["owm_key"]
         url = "https://api.openweathermap.org/data/2.5/forecast/daily"
         return requests.get(url, params=params).json()
 
@@ -233,12 +226,18 @@ def get_services_routes(app):
     @check_selene_pairing
     @requires_auth
     def owm_3h_forecast():
-        params = dict(request.args)
-        params["lang"] = request.args.get("lang") or _get_lang()
-        params["units"] = request.args.get("units") or _get_units()
+        lang = request.args.get("lang") or _get_lang()
+        units = request.args.get("units") or _get_units()
         lat, lon = request.args.get("lat"), request.args.get("lon")
         if not lat or not lon:
             lat, lon = _get_latlon()
+
+        if _selene_cfg.get("enabled") and _selene_cfg.get("proxy_weather"):
+            return _selene_owm.get_hourly((lat, lon), lang, units)
+
+        params = dict(request.args)
+        params["lang"] = lang
+        params["units"] = units
 
         if _owm:
             params["lat"], params["lon"] = lat, lon
@@ -255,21 +254,25 @@ def get_services_routes(app):
     @check_selene_pairing
     @requires_auth
     def owm():
-        params = dict(request.args)
-
-        params["lang"] = request.args.get("lang") or _get_lang()
-        params["units"] = request.args.get("units") or _get_units()
+        lang = request.args.get("lang") or _get_lang()
+        units = request.args.get("units") or _get_units()
         lat, lon = request.args.get("lat"), request.args.get("lon")
         if not lat or not lon:
             lat, lon = _get_latlon()
 
+        if _selene_cfg.get("enabled") and _selene_cfg.get("proxy_weather"):
+            return _selene_owm.get_current((lat, lon), lang, units)
+
+        params = dict(request.args)
+        params["lang"] = lang
+        params["units"] = units
         if _owm:
             params["lat"], params["lon"] = lat, lon
             return _owm.get_current(params).json()
 
-        params["appid"] = CONFIGURATION["owm_key"]
         if not request.args.get("q"):
             params["lat"], params["lon"] = lat, lon
+        params["appid"] = CONFIGURATION["owm_key"]
         url = "https://api.openweathermap.org/data/2.5/weather"
         return requests.get(url, params=params).json()
 
@@ -284,13 +287,8 @@ def get_services_routes(app):
         if not lat or not lon:
             lat, lon = _get_latlon()
 
-        selene_cfg = CONFIGURATION.get("selene") or {}
-        if selene_cfg.get("enabled") and selene_cfg.get("proxy_weather"):
-            url = selene_cfg.get("url")
-            version = selene_cfg.get("version") or "v1"
-            identity_file = selene_cfg.get("identity_file")
-            api = OpenWeatherMapApi(url, version, identity_file)
-            return api.get_weather((lat, lon), lang, units)
+        if _selene_cfg.get("enabled") and _selene_cfg.get("proxy_weather"):
+            return _selene_owm.get_weather((lat, lon), lang, units)
         elif _owm:
             params = {
                 "lang": lang,
@@ -312,6 +310,7 @@ def get_services_routes(app):
             else:
                 params["lat"], params["lon"] = lat, lon
 
+            params["appid"] = CONFIGURATION["owm_key"]
             url = "https://api.openweathermap.org/data/2.5/onecall"
             data = requests.get(url, params=params).json()
             # Selene converts the keys from snake_case to camelCase

--- a/ovos_local_backend/backend/external_apis.py
+++ b/ovos_local_backend/backend/external_apis.py
@@ -214,7 +214,6 @@ def get_services_routes(app):
             params["lat"], params["lon"] = lat, lon
             return _owm.get_forecast(params).json()
 
-        params = dict(request.args)
         params["appid"] = CONFIGURATION["owm_key"]
         if not request.args.get("q"):
             params["lat"], params["lon"] = lat, lon

--- a/ovos_local_backend/backend/external_apis.py
+++ b/ovos_local_backend/backend/external_apis.py
@@ -293,8 +293,7 @@ def get_services_routes(app):
                 "lang": lang,
                 "units": units,
                 "lat": lat,
-                "lon": lon,
-                "appid": CONFIGURATION["owm_key"]
+                "lon": lon
             }
             params["lat"], params["lon"] = lat, lon
             return _owm.get_weather_onecall(params).json()

--- a/ovos_local_backend/backend/precise.py
+++ b/ovos_local_backend/backend/precise.py
@@ -1,6 +1,6 @@
 from flask import request
 
-from ovos_local_backend.backend.decorators import noindex, requires_auth
+from ovos_local_backend.backend.decorators import noindex, requires_auth, check_selene_pairing
 from ovos_local_backend.configuration import CONFIGURATION
 from ovos_local_backend.database.wakewords import save_ww_recording
 
@@ -8,6 +8,7 @@ from ovos_local_backend.database.wakewords import save_ww_recording
 def get_precise_routes(app):
     @app.route('/precise/upload', methods=['POST'])
     @noindex
+    @check_selene_pairing
     @requires_auth
     def precise_upload():
         if CONFIGURATION["record_wakewords"]:
@@ -15,11 +16,13 @@ def get_precise_routes(app):
             uuid = auth.split(":")[-1]  # this split is only valid here, not selene
             save_ww_recording(uuid, request.files)
 
-        # TODO - share with upstream setting
-        # contribute to mycroft open dataset
-        # may require https://github.com/OpenVoiceOS/OVOS-local-backend/issues/20
         uploaded = False
-
+        selene_cfg = CONFIGURATION.get("selene") or {}
+        if selene_cfg.get("enabled") and \
+                selene_cfg.get("opt_in") and \
+                selene_cfg.get("upload_wakewords"):
+            # contribute to mycroft open dataset
+            pass  # TODO add upload endpoint to selene_api package
         return {"success": True,
                 "sent_to_mycroft": uploaded,
                 "saved": CONFIGURATION["record_wakewords"]}

--- a/ovos_local_backend/backend/precise.py
+++ b/ovos_local_backend/backend/precise.py
@@ -3,7 +3,7 @@ from flask import request
 from ovos_local_backend.backend.decorators import noindex, requires_auth, check_selene_pairing
 from ovos_local_backend.configuration import CONFIGURATION
 from ovos_local_backend.database.wakewords import save_ww_recording
-from ovos_local_backend.utils.selene import selene_opted_in
+from ovos_local_backend.utils.selene import upload_ww
 
 
 def get_precise_routes(app):
@@ -19,9 +19,10 @@ def get_precise_routes(app):
 
         uploaded = False
         selene_cfg = CONFIGURATION.get("selene") or {}
-        if selene_opted_in() and selene_cfg.get("upload_wakewords"):
+        if selene_cfg.get("upload_wakewords"):
             # contribute to mycroft open dataset
-            pass  # TODO add upload endpoint to selene_api package
+            uploaded = upload_ww(request.files)
+
         return {"success": True,
                 "sent_to_mycroft": uploaded,
                 "saved": CONFIGURATION["record_wakewords"]}

--- a/ovos_local_backend/backend/precise.py
+++ b/ovos_local_backend/backend/precise.py
@@ -3,6 +3,7 @@ from flask import request
 from ovos_local_backend.backend.decorators import noindex, requires_auth, check_selene_pairing
 from ovos_local_backend.configuration import CONFIGURATION
 from ovos_local_backend.database.wakewords import save_ww_recording
+from ovos_local_backend.utils.selene import selene_opted_in
 
 
 def get_precise_routes(app):
@@ -18,9 +19,7 @@ def get_precise_routes(app):
 
         uploaded = False
         selene_cfg = CONFIGURATION.get("selene") or {}
-        if selene_cfg.get("enabled") and \
-                selene_cfg.get("opt_in") and \
-                selene_cfg.get("upload_wakewords"):
+        if selene_opted_in() and selene_cfg.get("upload_wakewords"):
             # contribute to mycroft open dataset
             pass  # TODO add upload endpoint to selene_api package
         return {"success": True,

--- a/ovos_local_backend/backend/stt.py
+++ b/ovos_local_backend/backend/stt.py
@@ -15,12 +15,11 @@ from tempfile import NamedTemporaryFile
 
 from flask import request
 from speech_recognition import Recognizer, AudioFile
-from selene_api.api import STTApi
 from ovos_local_backend.backend import API_VERSION
 from ovos_local_backend.backend.decorators import noindex, requires_auth, check_selene_pairing
 from ovos_local_backend.configuration import CONFIGURATION
 from ovos_local_backend.database.utterances import save_stt_recording
-from ovos_local_backend.utils.selene import selene_opted_in
+from ovos_local_backend.utils.selene import upload_utterance
 from ovos_plugin_manager.stt import OVOSSTTFactory
 
 recognizer = Recognizer()
@@ -50,12 +49,9 @@ def get_stt_routes(app):
             save_stt_recording(uuid, audio, utterance)
 
         selene_cfg = CONFIGURATION.get("selene") or {}
-        if selene_opted_in() and selene_cfg.get("upload_utterances"):
-            url = selene_cfg.get("url")
-            version = selene_cfg.get("version") or "v1"
-            identity_file = selene_cfg.get("identity_file")
-            api = STTApi(url, version, identity_file)
-            api.stt(flac_audio, lang)
+        if selene_cfg.get("upload_utterances"):
+            upload_utterance(flac_audio, lang)
+
         return json.dumps([utterance])
 
     return app

--- a/ovos_local_backend/backend/stt.py
+++ b/ovos_local_backend/backend/stt.py
@@ -20,6 +20,7 @@ from ovos_local_backend.backend import API_VERSION
 from ovos_local_backend.backend.decorators import noindex, requires_auth, check_selene_pairing
 from ovos_local_backend.configuration import CONFIGURATION
 from ovos_local_backend.database.utterances import save_stt_recording
+from ovos_local_backend.utils.selene import selene_opted_in
 from ovos_plugin_manager.stt import OVOSSTTFactory
 
 recognizer = Recognizer()
@@ -49,9 +50,7 @@ def get_stt_routes(app):
             save_stt_recording(uuid, audio, utterance)
 
         selene_cfg = CONFIGURATION.get("selene") or {}
-        if selene_cfg.get("enabled") and \
-                selene_cfg.get("opt_in") and \
-                selene_cfg.get("upload_utterances"):
+        if selene_opted_in() and selene_cfg.get("upload_utterances"):
             url = selene_cfg.get("url")
             version = selene_cfg.get("version") or "v1"
             identity_file = selene_cfg.get("identity_file")

--- a/ovos_local_backend/configuration.py
+++ b/ovos_local_backend/configuration.py
@@ -82,7 +82,7 @@ DEFAULT_CONFIG = {
         # this will provide voice/gui prompts to the user and avoid the need to copy a identity file
         # only happens if backend is not paired with selene (hopefully exactly once)
         # if False you need to pair an existing mycroft-core as usual and move the file for backend usage
-        "proxy_pairing": True,
+        "proxy_pairing": False,
         # micro service settings
         # NOTE: STT is handled at plugin level, configure ovos-stt-plugin-selene
         "proxy_weather": True,  # use selene for weather api calls

--- a/ovos_local_backend/configuration.py
+++ b/ovos_local_backend/configuration.py
@@ -13,10 +13,22 @@
 from ovos_utils.log import LOG
 from os.path import exists
 from json_database import JsonConfigXDG
+from ovos_utils.configuration import get_xdg_data_save_path
+
+BACKEND_IDENTITY = f"{get_xdg_data_save_path('ovos_backend')}/identity2.json"
 
 DEFAULT_CONFIG = {
-    "stt": {"module": "ovos-stt-plugin-server",
-            "ovos-stt-plugin-server": {"url": "https://stt.openvoiceos.com/stt"}},
+    "stt": {
+        "module": "ovos-stt-plugin-server",
+        "ovos-stt-plugin-server": {
+            "url": "https://stt.openvoiceos.com/stt"
+        },
+        "ovos-stt-plugin-selene": {
+            "url": "https://api.mycroft.ai",
+            "version": "v1",
+            "identity_file": BACKEND_IDENTITY  # path to identity2.json file
+        }
+    },
     "backend_port": 6712,
     "admin_key": "",  # To enable simply set this string to something
     "skip_auth": False,  # you almost certainly do not want this, only for atypical use cases such as ovos-qubes
@@ -58,6 +70,37 @@ DEFAULT_CONFIG = {
     "email": {
         "username": None,
         "password": None
+    },
+    "selene": {
+        "enabled": False,  # needs to be explicitly enabled by user
+        "url": "https://api.mycroft.ai",  # change if you are self hosting selene
+        "version": "v1",
+        # pairing settings
+        # NOTE: the file should be used exclusively by backend, do not share with a mycroft-core instance
+        "identity_file": BACKEND_IDENTITY,  # path to identity2.json file
+        # send the pairing from selene to any device that attempts to pair with local backend
+        # this will provide voice/gui prompts to the user and avoid the need to copy a identity file
+        # only happens if backend is not paired with selene (hopefully exactly once)
+        # if False you need to pair an existing mycroft-core as usual and move the file for backend usage
+        "proxy_pairing": True,
+        # micro service settings
+        # NOTE: STT is handled at plugin level, configure ovos-stt-plugin-selene
+        "proxy_weather": True,  # use selene for weather api calls
+        "proxy_wolfram": True,  # use selene for wolfram alpha api calls
+        "proxy_geolocation": True,  # use selene for geolocation api calls
+        "proxy_email": True,  # use selene for sending email (only for email registered in selene)
+        # device settings - if you want to spoof data in selene set these to False
+        "download_location": True,  # set default location from selene
+        "download_prefs": True,  # set default device preferences from selene
+        "download_settings": True,  # download shared skill settings from selene
+        "upload_settings": True,  # upload shared skill settings to selene
+        # opt-in settings - what data to share with selene
+        # NOTE: these also depend on opt_in being set in selene
+        "opt_in": False,  # share data from all devices with selene (as if from a single device)
+        "opt_in_blacklist": [],  # list of uuids that should ignore opt_in flag (never share data)
+        "upload_metrics": True,  # upload device metrics to selene
+        "upload_wakewords": True,  # upload wake word samples to selene
+        "upload_utterances": True  # upload utterance samples to selene
     }
 }
 
@@ -67,4 +110,8 @@ if not exists(CONFIGURATION.path):
     CONFIGURATION.store()
     LOG.info(f"Saved default configuration: {CONFIGURATION.path}")
 else:
+    # set any new default values since file creation
+    for k, v in DEFAULT_CONFIG.items():
+        if k not in CONFIGURATION:
+            CONFIGURATION[k] = v
     LOG.info(f"Loaded configuration: {CONFIGURATION.path}")

--- a/ovos_local_backend/configuration.py
+++ b/ovos_local_backend/configuration.py
@@ -89,7 +89,7 @@ DEFAULT_CONFIG = {
         "proxy_weather": True,  # use selene for weather api calls
         "proxy_wolfram": True,  # use selene for wolfram alpha api calls
         "proxy_geolocation": True,  # use selene for geolocation api calls
-        "proxy_email": True,  # use selene for sending email (only for email registered in selene)
+        "proxy_email": False,  # use selene for sending email (only for email registered in selene)
 
         # device settings - if you want to spoof data in selene set these to False
         "download_location": True,  # set default location from selene

--- a/ovos_local_backend/configuration.py
+++ b/ovos_local_backend/configuration.py
@@ -83,17 +83,25 @@ DEFAULT_CONFIG = {
         # only happens if backend is not paired with selene (hopefully exactly once)
         # if False you need to pair an existing mycroft-core as usual and move the file for backend usage
         "proxy_pairing": False,
+
         # micro service settings
         # NOTE: STT is handled at plugin level, configure ovos-stt-plugin-selene
         "proxy_weather": True,  # use selene for weather api calls
         "proxy_wolfram": True,  # use selene for wolfram alpha api calls
         "proxy_geolocation": True,  # use selene for geolocation api calls
         "proxy_email": True,  # use selene for sending email (only for email registered in selene)
+
         # device settings - if you want to spoof data in selene set these to False
         "download_location": True,  # set default location from selene
         "download_prefs": True,  # set default device preferences from selene
         "download_settings": True,  # download shared skill settings from selene
         "upload_settings": True,  # upload shared skill settings to selene
+        "force2way": False,  # this forcefully re-enables 2way settings sync with selene
+        # this functionality was removed from core, we hijack the settingsmeta endpoint to upload settings
+        # upload will happen when mycroft-core boots and overwrite any values in selene (no checks for settings changed)
+        # the assumption is that selene changes are downloaded instantaneously
+        # if a device is offline when selene changes those changes will be discarded on next device boot
+
         # opt-in settings - what data to share with selene
         # NOTE: these also depend on opt_in being set in selene
         "opt_in": False,  # share data from all devices with selene (as if from a single device)

--- a/ovos_local_backend/utils/selene.py
+++ b/ovos_local_backend/utils/selene.py
@@ -141,7 +141,10 @@ def selene_opted_in():
     uuid = auth.split(":")[-1]  # this split is only valid here, not selene
     if uuid in _selene_cfg.get("opt_in_blacklist", []):
         return False
-    # TODO check device db for per-device opt_in settings
+    # check device db for per-device opt_in settings
+    device = DeviceDatabase().get_device(uuid)
+    if not device or not device.opt_in:
+        return False
     return True
 
 

--- a/ovos_local_backend/utils/selene.py
+++ b/ovos_local_backend/utils/selene.py
@@ -7,7 +7,7 @@ from selene_api.identity import IdentityManager
 from selene_api.pairing import has_been_paired
 
 from ovos_local_backend.configuration import CONFIGURATION, BACKEND_IDENTITY
-from ovos_local_backend.database.settings import SkillSettings, SettingsDatabase, DeviceDatabase
+from ovos_local_backend.database.settings import SkillSettings, SharedSettingsDatabase, DeviceDatabase
 
 _selene_pairing_data = None
 _selene_uuid = uuid4()
@@ -56,8 +56,8 @@ def download_selene_skill_settings():
         for skill_id, s in sets.items():
             s = SkillSettings.deserialize(s)
             # sync local db with selene
-            with SettingsDatabase() as db:
-                db.add_setting(s.uuid, s.skill_id, s.settings, s.meta,
+            with SharedSettingsDatabase() as db:
+                db.add_setting(s.skill_id, s.settings, s.meta,
                                s.display_name, s.remote_id)
 
 

--- a/ovos_local_backend/utils/selene.py
+++ b/ovos_local_backend/utils/selene.py
@@ -1,0 +1,104 @@
+from uuid import uuid4
+
+from flask import request
+from ovos_utils.log import LOG
+from selene_api.api import DeviceApi
+from selene_api.identity import IdentityManager
+from selene_api.pairing import has_been_paired
+
+from ovos_local_backend.configuration import CONFIGURATION, BACKEND_IDENTITY
+
+_selene_pairing_data = None
+_selene_uuid = uuid4()
+_selene_cfg = CONFIGURATION.get("selene") or {}
+
+_ident_file = _selene_cfg.get("identity_file", "")
+if _ident_file != IdentityManager.IDENTITY_FILE:
+    IdentityManager.set_identity_file(_ident_file)
+
+_device_api = DeviceApi(_selene_cfg.get("url"),
+                        _selene_cfg.get("version") or "v1",
+                        _selene_cfg.get("identity_file"))
+
+
+def requires_selene_pairing(func_name):
+    enabled = _selene_cfg.get("enabled")
+    check_pairing = False
+    if enabled:
+        # identity file settings
+        check_pairing = True
+
+        # individual selene integration settings
+        if "wolfie" in func_name and not _selene_cfg.get("proxy_wolfram"):
+            check_pairing = False
+        elif "owm" in func_name and not _selene_cfg.get("proxy_weather"):
+            check_pairing = False
+        elif func_name == "geolocation" and not _selene_cfg.get("proxy_geolocation"):
+            check_pairing = False
+        elif func_name == "send_mail" and not _selene_cfg.get("proxy_email"):
+            check_pairing = False
+        elif func_name == "location" and not _selene_cfg.get("download_location"):
+            check_pairing = False
+        elif func_name in ["get_uuid", "setting"] and \
+                (not _selene_cfg.get("download_prefs") or request.method == 'PATCH'):
+            check_pairing = False
+        elif func_name == "setting" and not _selene_cfg.get("download_prefs"):
+            check_pairing = False
+        elif func_name == "settingsmeta" and not _selene_cfg.get("upload_settings"):
+            check_pairing = False
+        elif "skill_settings" in func_name:
+            if request.method == 'PUT':
+                if not _selene_cfg.get("upload_settings"):
+                    check_pairing = False
+            elif not _selene_cfg.get("download_settings"):
+                check_pairing = False
+
+        # check global opt in settings
+        opt_in = _selene_cfg.get("opt_in")
+        opts = ["precise_upload", "stt", "metric"]
+        if not opt_in and func_name in opts:
+            check_pairing = False
+        else:
+            if func_name == "precise_upload" and not _selene_cfg.get("upload_wakewords"):
+                check_pairing = False
+            if func_name == "stt" and not _selene_cfg.get("upload_utterances"):
+                check_pairing = False
+            if func_name == "metric" and not _selene_cfg.get("upload_metrics"):
+                check_pairing = False
+
+    return check_pairing
+
+
+def get_selene_code():
+    _selene_pairing_data = get_selene_pairing_data()
+    return _selene_pairing_data.get("code")
+
+
+def get_selene_pairing_data():
+    global _selene_pairing_data
+    if not _selene_pairing_data:
+        try:
+            _selene_pairing_data = _device_api.get_code(_selene_uuid)
+        except:
+            LOG.exception("Failed to get selene pairing data")
+    return _selene_pairing_data or {}
+
+
+def attempt_selene_pairing():
+    backend_version = "0.0.1"
+    platform = "ovos-local-backend"
+    ident_file = _selene_cfg.get("identity_file") or BACKEND_IDENTITY
+    if ident_file != IdentityManager.IDENTITY_FILE:
+        IdentityManager.set_identity_file(ident_file)
+    if _selene_cfg.get("enabled") and not has_been_paired():
+        data = get_selene_pairing_data()
+        if data:
+            tok = data["token"]
+            try:
+                _device_api.activate(_selene_uuid, tok,
+                                     platform=platform,
+                                     platform_build=backend_version,
+                                     core_version=backend_version,
+                                     enclosure_version=backend_version)
+            except:
+                LOG.exception("Failed to pair with selene")

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -8,3 +8,4 @@ ovos-stt-plugin-server
 geocoder
 timezonefinder
 requests_cache
+selene_api>=0.0.1


### PR DESCRIPTION
closes #20 


## Selene Proxy

You can integrate local backend with selene, the backend will show up as a device you can manage in mycroft.home

wait... what? isn't the point of local backend to disable selene?

- Open Dataset, You do not want to use selene, but you want to opt_in to the open dataset (share recordings with mycroft)
- Privacy, you want to use selene, but you do not want to give away your personal data (email, location, ip address...)
- Control, you want to use only a subset of selene features
- Convenience, pair once, manage all your devices
- Functionality, extra features such as isolated skill settings and forced 2 way sync
- Esoteric Setups, isolated mycroft services that can not share a identity file, such as [ovos-qubes](https://github.com/OpenVoiceOS/ovos-qubes)

### Pairing

To pair the local backend with selene you have 2 options

1 - pair a mycroft-core instance, then copy the identity file

2 - enable proxy_pairing, whenever a device pairs with local backend the code it speaks is also valid for selene, use that code to pair local backend with selene

### Selene Config

In your backend config add the following section

```python
    "selene": {
        "enabled": False,  # needs to be explicitly enabled by user
        "url": "https://api.mycroft.ai",  # change if you are self hosting selene
        "version": "v1",
        # pairing settings
        # NOTE: the file should be used exclusively by backend, do not share with a mycroft-core instance
        "identity_file": BACKEND_IDENTITY,  # path to identity2.json file
        # send the pairing from selene to any device that attempts to pair with local backend
        # this will provide voice/gui prompts to the user and avoid the need to copy a identity file
        # only happens if backend is not paired with selene (hopefully exactly once)
        # if False you need to pair an existing mycroft-core as usual and move the file for backend usage
        "proxy_pairing": False,
        
        # micro service settings
        # NOTE: STT is handled at plugin level, configure ovos-stt-plugin-selene
        "proxy_weather": True,  # use selene for weather api calls
        "proxy_wolfram": True,  # use selene for wolfram alpha api calls
        "proxy_geolocation": True,  # use selene for geolocation api calls
        "proxy_email": True,  # use selene for sending email (only for email registered in selene)
        
        # device settings - if you want to spoof data in selene set these to False
        "download_location": True,  # set default location from selene
        "download_prefs": True,  # set default device preferences from selene
        "download_settings": True,  # download shared skill settings from selene
        "upload_settings": True,  # upload shared skill settings to selene
        "force2way": False,  # this forcefully re-enables 2way settings sync with selene
        # this functionality was removed from core, we hijack the settingsmeta endpoint to upload settings
        # upload will happen when mycroft-core boots and overwrite any values in selene (no checks for settings changed)
        # the assumption is that selene changes are downloaded instantaneously
        # if a device is offline when selene changes those changes will be discarded on next device boot
        
        # opt-in settings - what data to share with selene
        # NOTE: these also depend on opt_in being set in selene
        "opt_in": False,  # share data from all devices with selene (as if from a single device)
        "opt_in_blacklist": [],  # list of uuids that should ignore opt_in flag (never share data)
        "upload_metrics": True,  # upload device metrics to selene
        "upload_wakewords": True,  # upload wake word samples to selene
        "upload_utterances": True  # upload utterance samples to selene
    }
```
